### PR TITLE
Migrate to filebeat oss 8.5.3

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,92 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - '*'
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+       # Get the repository's code
+      - name: Checkout
+        uses: actions/checkout@v3
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Docker meta
+        id: dockeraction # you'll use this in the next step
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            logzio/mysql-logs
+          flavor: |
+            latest=false
+          # Docker tags based on the following events/attributes
+
+      - name: Build and push amd64
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dockeraction.outputs.tags }}-amd
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+
+      - name: Build and push amd64 latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: logzio/mysql-logs:latest-amd
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Build and push arm64 latest
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.arm
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: logzio/mysql-logs:latest-arm
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.arm
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.dockeraction.outputs.tags }}-arm
+          labels: ${{ steps.dockeraction.outputs.labels }}
+
+      - name: Create manifest version
+        run: |
+          docker manifest create ${{ steps.dockeraction.outputs.tags }} --amend ${{ steps.dockeraction.outputs.tags }}-arm --amend ${{ steps.dockeraction.outputs.tags }}-amd
+
+      - name: Create manifest latest
+        run: |
+          docker manifest create logzio/mysql-logs:latest --amend logzio/mysql-logs:latest-arm --amend logzio/mysql-logs:latest-amd
+
+      - name: Push manifest latest
+        run: |
+          docker manifest push logzio/mysql-logs:latest
+      - name: Push manifest version
+        run: |
+          docker manifest push ${{ steps.dockeraction.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get install -y bc curl wget unzip less
 # RUN pip install awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.5.3-amd64.deb
-RUN dpkg -i filebeat-8.5.3-amd64.deb
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-8.5.3-amd64.deb
+RUN dpkg -i filebeat-oss-8.5.3-amd64.deb
 
 ENV LOGZIO_LOGS_DIR /var/log/logzio
 ENV MYSQL_LOGS_DIR /var/log/mysql

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -8,8 +8,8 @@ RUN apt-get install -y bc curl wget unzip less
 # RUN pip install awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.5.3-arm64.deb
-RUN dpkg -i filebeat-8.5.3-arm64.deb
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-8.5.3-arm64.deb
+RUN dpkg -i filebeat-oss-8.5.3-arm64.deb
 
 ENV LOGZIO_LOGS_DIR /var/log/logzio
 ENV MYSQL_LOGS_DIR /var/log/mysql

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ docker run -d \
 - [Deploying to Kubernetes](https://github.com/logzio/logzio-mysql-logs/tree/master/k8s)
 
 ## Changelog:
+
+- **1.2.0**:
+  - Migrate to Filebeat oss 8.5.3.
 - **1.1.0**:
   - Docker image now supprts arm64 arch.
   - Upgrade to Filebeat 8.5.3.

--- a/k8s/logzio-deployment.yaml
+++ b/k8s/logzio-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: logzio-mysql-logs
-        image: "logzio/mysql-logs:1.0.0"
+        image: "logzio/mysql-logs:1.2.0"
         env:
         - name: LOGZIO_TOKEN
           valueFrom:


### PR DESCRIPTION
In this PR:
- Migrate to filebeat oss 8.5.3.
- Update readme.
- Update k8s deployment to use latest image.
- Add deployment workflow.