### PR TITLE
Release `logzio-mysql-logs` v1.3.0

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
           # Docker tags based on the following events/attributes
 
       - name: Build and push amd64
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
@@ -48,7 +48,7 @@ jobs:
 
 
       - name: Build and push amd64 latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64
@@ -57,7 +57,7 @@ jobs:
           labels: ${{ steps.dockeraction.outputs.labels }}
 
       - name: Build and push arm64 latest
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.arm
@@ -67,7 +67,7 @@ jobs:
           labels: ${{ steps.dockeraction.outputs.labels }}
 
       - name: Build and push arm64
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.arm

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+docker-compose.yml
+my.cnf
+/test-volumes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-MAINTAINER Miri Bar <miri.ignatiev@logz.io>
 
 RUN apt-get update
 # RUN apt-get install -y python-pip
@@ -8,23 +7,21 @@ RUN apt-get install -y bc curl wget unzip less
 # RUN pip install awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-8.5.3-amd64.deb
-RUN dpkg -i filebeat-oss-8.5.3-amd64.deb
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-9.0.4-amd64.deb
+RUN apt-get install -y ./filebeat-oss-9.0.4-amd64.deb
 
-ENV LOGZIO_LOGS_DIR /var/log/logzio
-ENV MYSQL_LOGS_DIR /var/log/mysql
-ENV JAVA_HOME /usr/
-ENV AWS_CREDENTIAL_FILE /root/.aws/credentials
-ENV FILEBEAT_CONF /etc/filebeat/filebeat.yml
-ENV MYSQL_ERROR_LOG_FILE ""
-ENV MYSQL_SLOW_LOG_FILE ""
-ENV MYSQL_LOG_FILE ""
+ENV LOGZIO_LOGS_DIR=/var/log/logzio
+ENV MYSQL_LOGS_DIR=/var/log/mysql
+ENV JAVA_HOME=/usr/
+ENV AWS_CREDENTIAL_FILE=/root/.aws/credentials
+ENV FILEBEAT_CONF=/etc/filebeat/filebeat.yml
+ENV MYSQL_ERROR_LOG_FILE=""
+ENV MYSQL_SLOW_LOG_FILE=""
+ENV MYSQL_LOG_FILE=""
 
-RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /root
-RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /root
+RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/AAACertificateServices.crt -P /root
 RUN mkdir -p /etc/pki/tls/certs
-RUN cp /root/COMODORSADomainValidationSecureServerCA.crt /etc/pki/tls/certs/
-RUN cp /root/SectigoRSADomainValidationSecureServerCA.crt /etc/pki/tls/certs/
+RUN cp /root/AAACertificateServices.crt /etc/pki/tls/certs/
 
 RUN mkdir -p $MYSQL_LOGS_DIR
 RUN mkdir -p $LOGZIO_LOGS_DIR
@@ -35,6 +32,9 @@ ADD scripts/base.sh /root/
 ADD files/filebeat.yaml $FILEBEAT_CONF
 ADD files/filebeat-rds.yaml /root/
 
+# Make scripts executable
+RUN chmod +x /root/go.bash /root/utils.sh /root/base.sh
+
 WORKDIR /root
-CMD "/root/go.bash"
+CMD ["/root/go.bash"]
 		

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,6 +1,5 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-MAINTAINER Miri Bar <miri.ignatiev@logz.io>
 
 RUN apt-get update
 # RUN apt-get install -y python-pip
@@ -8,23 +7,21 @@ RUN apt-get install -y bc curl wget unzip less
 # RUN pip install awscli
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-8.5.3-arm64.deb
-RUN dpkg -i filebeat-oss-8.5.3-arm64.deb
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-9.0.4-arm64.deb
+RUN apt-get install -y ./filebeat-oss-9.0.4-arm64.deb
 
-ENV LOGZIO_LOGS_DIR /var/log/logzio
-ENV MYSQL_LOGS_DIR /var/log/mysql
-ENV JAVA_HOME /usr/
-ENV AWS_CREDENTIAL_FILE /root/.aws/credentials
-ENV FILEBEAT_CONF /etc/filebeat/filebeat.yml
-ENV MYSQL_ERROR_LOG_FILE ""
-ENV MYSQL_SLOW_LOG_FILE ""
-ENV MYSQL_LOG_FILE ""
+ENV LOGZIO_LOGS_DIR=/var/log/logzio
+ENV MYSQL_LOGS_DIR=/var/log/mysql
+ENV JAVA_HOME=/usr/
+ENV AWS_CREDENTIAL_FILE=/root/.aws/credentials
+ENV FILEBEAT_CONF=/etc/filebeat/filebeat.yml
+ENV MYSQL_ERROR_LOG_FILE=""
+ENV MYSQL_SLOW_LOG_FILE=""
+ENV MYSQL_LOG_FILE=""
 
-RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/COMODORSADomainValidationSecureServerCA.crt -P /root
-RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/SectigoRSADomainValidationSecureServerCA.crt -P /root
+RUN wget https://raw.githubusercontent.com/logzio/public-certificates/master/AAACertificateServices.crt -P /root
 RUN mkdir -p /etc/pki/tls/certs
-RUN cp /root/COMODORSADomainValidationSecureServerCA.crt /etc/pki/tls/certs/
-RUN cp /root/SectigoRSADomainValidationSecureServerCA.crt /etc/pki/tls/certs/
+RUN cp /root/AAACertificateServices.crt /etc/pki/tls/certs/
 
 RUN mkdir -p $MYSQL_LOGS_DIR
 RUN mkdir -p $LOGZIO_LOGS_DIR
@@ -35,6 +32,8 @@ ADD scripts/base.sh /root/
 ADD files/filebeat.yaml $FILEBEAT_CONF
 ADD files/filebeat-rds.yaml /root/
 
+# Make scripts executable
+RUN chmod +x /root/go.bash /root/utils.sh /root/base.sh
+
 WORKDIR /root
-CMD "/root/go.bash"
-		
+CMD ["/root/go.bash"]

--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ docker run -d \
 - [Deploying to Kubernetes](https://github.com/logzio/logzio-mysql-logs/tree/master/k8s)
 
 ## Changelog:
-
+- **1.3.0**:
+  - Upgraded Filebeat OSS to version 9.0.4.
+  - Upgraded Ubuntu base image to 24.04.
+  - Updated Logz.io listener certificate to `AAACertificateServices.crt`.
+  - Updated the Kubernetes deployment to use the `1.3.0` image tag.
+  - Improved Filebeat execution and cleanup scripts.
 - **1.2.0**:
   - Migrate to Filebeat oss 8.5.3.
 - **1.1.0**:

--- a/files/filebeat-rds.yaml
+++ b/files/filebeat-rds.yaml
@@ -62,7 +62,7 @@ output:
     hosts: ["${LOGZIO_LISTENER}:5015"]      
     #  The below configuration is used for Filebeat 5.0 or higher      
     ssl:
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt','/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt']
+      certificate_authorities: ['/etc/pki/tls/certs/AAACertificateServices.crt']
 logging:
   to_files: true
   files:

--- a/files/filebeat.yaml
+++ b/files/filebeat.yaml
@@ -61,7 +61,7 @@ output:
     hosts: ["${LOGZIO_LISTENER}:5015"]
     #  The below configuration is used for Filebeat 5.0 or higher      
     ssl:
-      certificate_authorities: ['/etc/pki/tls/certs/COMODORSADomainValidationSecureServerCA.crt','/etc/pki/tls/certs/SectigoRSADomainValidationSecureServerCA.crt']
+      certificate_authorities: ['/etc/pki/tls/certs/AAACertificateServices.crt']
 logging:
   to_files: true
   files:

--- a/k8s/logzio-deployment.yaml
+++ b/k8s/logzio-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: logzio-mysql-logs
-        image: "logzio/mysql-logs:1.2.0"
+        image: "logzio/mysql-logs:1.3.0"
         env:
         - name: LOGZIO_TOKEN
           valueFrom:

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -177,7 +177,8 @@ function restart_filebeat() {
     log "INFO" "LOGZIO_TOKEN: $LOGZIO_TOKEN"
     log "INFO" "LOGZIO_LISTENER: $LOGZIO_LISTENER"
 
-    execute /etc/init.d/filebeat start
+    # Run filebeat in the background
+    filebeat -e -c /etc/filebeat/filebeat.yml &
 }
 
 # ---------------------------------------- 

--- a/scripts/go.bash
+++ b/scripts/go.bash
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 function cleanup() {
-	kill -9 $(</run/sqlmonitor.pid)
+	# Stop filebeat
+    kill $(pidof filebeat)
 
 	echo "Exiting..."
 }


### PR DESCRIPTION
- 1.3.0:
  - Upgraded Filebeat OSS to version 9.0.4.
  - Upgraded Ubuntu base image to 24.04.
  - Updated Logz.io listener certificate to `AAACertificateServices.crt`.
  - Updated `docker/build-push-action` to `v6` in the deployment workflow.
  - Updated the Kubernetes deployment to use the `1.3.0` image tag.
  - Improved Filebeat execution and cleanup scripts.

## Description 

<!-- 
    "This PR [adds/removes/fixes/replaces] the [feature/bug/etc].."
    Do not leave this blank.
    If relevant, describe the previous behaviour compared to the behaviour post your code change.
-->

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
